### PR TITLE
Fix linking on macOS when using Homebrew toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ $ imppg
 
 To enable OpenMP with Homebrew toolchain invoke `cmake` with following variables:
 ```bash
-CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib" CPPFLAGS="-I/usr/local/opt/llvm/include" cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++" CPPFLAGS="-I/usr/local/opt/llvm/include" \
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
 ```
 
 ----------------------------------------


### PR DESCRIPTION
The OpenMP enabling (using Homebrew llvm toolchain) instructions fail on macOS (at least on 14.5) with

```
[ 63%] Linking CXX executable imppg
ld: warning: ignoring duplicate libraries: '-lcfitsio', '-lwx_baseu-3.2', '-lwx_baseu_xml-3.2', '-lwx_osx_cocoau_aui-3.2', '-lwx_osx_cocoau_core-3.2', '-lwx_osx_cocoau_gl-3.2', '-lwx_osx_cocoau_richtext-3.2', 'src/alignment/libalignment.a', 'src/backend/libbackend.a', 'src/common/libcommon.a', 'src/image/libimage.a', 'src/logging/liblogging.a', 'src/math_utils/libmath_utils.a'
Undefined symbols for architecture x86_64:
  "std::exception_ptr::__from_native_exception_pointer(void*)", referenced from:
      std::__1::promise<std::__1::variant<scripting::call_result::Success, scripting::call_result::ImageProcessed, scripting::call_result::Error>>::~promise() in script_dialog.cpp.o
  "___cxa_init_primary_exception", referenced from:
      std::__1::promise<std::__1::variant<scripting::call_result::Success, scripting::call_result::ImageProcessed, scripting::call_result::Error>>::~promise() in script_dialog.cpp.o
ld: symbol(s) not found for architecture x86_64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

It appears similar to [this issue](https://github.com/Homebrew/homebrew-core/issues/169820#issuecomment-2071462943) and the same fix seems to work for now. When llvm fixes the issue then this flag may not be required.

Also add cosmetic shell line break in doc to avoid horizontal scrolling.