### PR TITLE
macOS: build on Tahoe + fix .app bundle resource lookup + dark-mode icons

### DIFF
--- a/src/alignment/CMakeLists.txt
+++ b/src/alignment/CMakeLists.txt
@@ -11,6 +11,13 @@ add_library(alignment STATIC
 
 set_compiler_options(alignment)
 
+# Workaround: Apple Clang 21 (Xcode on macOS Tahoe) frontend segfaults compiling
+# align_phasecorr.cpp at -O2/-O3 with Boost 1.90 uBLAS templates. Compile this
+# file at -O1 to avoid the crash.
+if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set_source_files_properties(src/align_phasecorr.cpp PROPERTIES COMPILE_FLAGS "-O1")
+endif()
+
 if(USE_FREEIMAGE EQUAL 1)
     target_compile_definitions(alignment PRIVATE USE_FREEIMAGE=1)
 endif()

--- a/src/backend/src/opengl/gl_utils.cpp
+++ b/src/backend/src/opengl/gl_utils.cpp
@@ -204,15 +204,23 @@ void BindProgramTextures(c_Program& program, std::initializer_list<std::pair<con
 
 wxFileName GetShadersDirectory()
 {
-    auto shaderDir = wxFileName(wxStandardPaths::Get().GetExecutablePath());
+    wxFileName shaderDir = wxFileName::DirName(
+        wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath());
     shaderDir.AppendDir("shaders");
-    if (!shaderDir.Exists())
+    if (!shaderDir.DirExists())
     {
-        shaderDir.AssignCwd();
+#ifdef __APPLE__
+        shaderDir = wxFileName::DirName(wxStandardPaths::Get().GetResourcesDir());
         shaderDir.AppendDir("shaders");
-        if (!shaderDir.Exists())
+        if (!shaderDir.DirExists())
+#endif
         {
-            shaderDir.AssignDir(IMPPG_SHADERS_DIR); // defined in CMakeLists.txt
+            shaderDir.AssignCwd();
+            shaderDir.AppendDir("shaders");
+            if (!shaderDir.DirExists())
+            {
+                shaderDir.AssignDir(IMPPG_SHADERS_DIR); // defined in CMakeLists.txt
+            }
         }
     }
 

--- a/src/common/src/common.cpp
+++ b/src/common/src/common.cpp
@@ -29,6 +29,7 @@ File description:
 #include <cstdlib>
 #include <wx/defs.h> // For some reason, this is needed before display.h, otherwise there are a lot of WXDLLIMPEXP_FWD_CORE undefined errors
 #include <wx/display.h>
+#include <wx/settings.h>
 
 /// Checks if a window is visible on any display; if not, sets its size and position to default
 void FixWindowPosition(wxWindow& wnd)
@@ -43,28 +44,37 @@ void FixWindowPosition(wxWindow& wnd)
     }
 }
 
-/// Loads a bitmap from the "images" subdirectory, optionally scaling it
+/// Loads a bitmap from the "images" subdirectory, optionally scaling it.
+/// In dark mode the RGB channels are inverted (alpha preserved) so that the
+/// dark-on-transparent source icons remain visible on a dark toolbar.
 wxBitmap LoadBitmap(wxString name, std::optional<wxSize> scaledSize)
 {
     wxFileName fName = GetImagesDirectory();
     fName.SetName(name);
     fName.SetExt("png");
 
-    wxBitmap result(fName.GetFullPath(), wxBITMAP_TYPE_ANY);
-    if (!result.IsOk())
+    wxImage img(fName.GetFullPath(), wxBITMAP_TYPE_ANY);
+    if (!img.IsOk())
+        return wxBitmap(16, 16); //TODO: show some warning/working path suggestion message
+
+    if (wxSystemSettings::GetAppearance().IsDark())
     {
-        result = wxBitmap(16, 16); //TODO: show some warning/working path suggestion message
+        unsigned char* rgb = img.GetData();
+        const int npx = img.GetWidth() * img.GetHeight();
+        for (int i = 0; i < npx * 3; ++i)
+            rgb[i] = static_cast<unsigned char>(255 - rgb[i]);
     }
-    else if (scaledSize.has_value())
+
+    if (scaledSize.has_value())
     {
-        result = wxBitmap(result.ConvertToImage().Scale(
+        img = img.Scale(
             scaledSize->GetWidth(),
             scaledSize->GetHeight(),
             wxIMAGE_QUALITY_BICUBIC
-        ));
+        );
     }
 
-    return result; // Return by value; it's fast, because wxBitmap's copy constructor uses reference counting
+    return wxBitmap(img);
 }
 
 Histogram DetermineHistogram(const c_Image& img, const wxRect& selection)

--- a/src/common/src/dirs.cpp
+++ b/src/common/src/dirs.cpp
@@ -32,15 +32,29 @@ wxFileName GetImagesDirectory()
 {
     wxFileName imgDir;
     imgDir.AssignDir(IMPPG_IMAGES_DIR); // defined in CMakeLists.txt
-    if (!imgDir.Exists())
+    if (!imgDir.DirExists())
     {
-        imgDir = wxFileName{wxStandardPaths::Get().GetExecutablePath()};
+        // Use a directory-typed wxFileName so AppendDir/DirExists evaluate
+        // against the directory itself, not against a synthesized
+        // "<dir>/images/<exe-name>" path (which would never exist).
+        imgDir = wxFileName::DirName(
+            wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath());
         imgDir.AppendDir("images");
 
-        if (!imgDir.Exists())
+        if (!imgDir.DirExists())
         {
-            imgDir.AssignCwd();
+#ifdef __APPLE__
+            // macOS .app bundle: also look in Contents/Resources/.
+            // (Cocoa resets CWD to "/" before wxApp::OnInit, so the CWD
+            // fallback below is unreliable inside a bundle.)
+            imgDir = wxFileName::DirName(wxStandardPaths::Get().GetResourcesDir());
             imgDir.AppendDir("images");
+            if (!imgDir.DirExists())
+#endif
+            {
+                imgDir.AssignCwd();
+                imgDir.AppendDir("images");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Three independent fixes encountered while building and running ImPPG on macOS Tahoe 26 with Xcode 21 / Boost 1.90 / wxWidgets 3.3, including from a `.app` bundle:

- **Build:** Apple Clang 21 frontend segfaults compiling `align_phasecorr.cpp` at `-O2`/`-O3` against Boost 1.90's uBLAS templates. Force `-O1` for that single file when the compiler is AppleClang.
- **Resource lookup:** `GetImagesDirectory()` and `GetShadersDirectory()` constructed a `wxFileName` from the executable's full path (with the binary's filename still present) and called `AppendDir("images")`, which produces `.../images/<exe-name>` — a path that never exists. The check therefore always fell through to the CWD lookup. That happens to work when launching from the build dir, but inside a macOS `.app` bundle Cocoa resets CWD to `/` before `wxApp::OnInit` runs, so neither the exe-relative nor the CWD lookup resolves — toolbar icons render as 16×16 blanks and the GPU backend dies with a fatal "could not load shader" on the first operation. Switch to `wxFileName::DirName(...)` + `DirExists()` and add a `wxStandardPaths::GetResourcesDir()` fallback on macOS so resources can also live in `Contents/Resources/` as Apple expects.
- **Dark mode icons:** The bundled icons are dark-on-transparent and disappear into a dark-mode toolbar. When `wxSystemSettings::GetAppearance().IsDark()` is true, invert RGB at load time (alpha preserved) so the same source PNGs remain visible in both modes without shipping a duplicate icon set.

## Test plan

- [x] Builds cleanly on macOS Tahoe 26.3 / Xcode 21 / Apple Silicon M3 Max with the README's "simple build (no OpenMP, native Xcode toolchain)" instructions.
- [x] Launches from `build/` as before — toolbar icons render, image loads, GPU backend processes.
- [x] Launches as a `.app` bundle (binary in `Contents/MacOS/`, resources in `Contents/MacOS/images` + `Contents/MacOS/shaders`) on M3 Max and M1 (after embedding Homebrew dylibs with `dylibbundler`) — same.
- [x] Toolbar icons readable in both macOS dark and light mode (toggled via System Settings → Appearance).

Notes for reviewer:
- The macOS `.app` bundling itself (Info.plist, `.icns` generation, `dylibbundler`) is *not* in this PR — these fixes are the source-level prerequisites; packaging is downstream work.
- The Apple Clang workaround is gated on `CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"` and only touches one file's optimization level; Linux/MSYS2 builds are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
