### PR TITLE
Do not abort in-progress sharpening for downstream setting changes

### DIFF
--- a/src/backend/src/cpu_bmp/cpu_bmp_proc.cpp
+++ b/src/backend/src/cpu_bmp/cpu_bmp_proc.cpp
@@ -33,6 +33,41 @@ File description:
 
 namespace imppg::backend {
 
+namespace {
+
+/// Returns true if a pipeline currently executing `inProgress` will, on
+/// completion, naturally chain forward through the step `target`. When true,
+/// a `ScheduleProcessing(target)` call can safely no-op: each step in the
+/// chain reads the latest `m_ProcSettings` at its start, so settings changes
+/// downstream of `inProgress` take effect when the chain reaches them without
+/// having to restart upstream work. Without this guard, rapid tone-curve or
+/// unsharp-mask changes during a slow L-R deconvolution would abort and
+/// restart the L-R on every change, preventing it from ever completing.
+bool ChainWillReach(const ProcessingRequest& inProgress, const ProcessingRequest& target)
+{
+    return std::visit(Overload{
+        [&](const req_type::Sharpening&) {
+            // Sharpening chains forward through every UnsharpMasking step and
+            // ToneCurve. A new Sharpening request, however, means parameters
+            // changed and the L-R must restart.
+            return !std::holds_alternative<req_type::Sharpening>(target);
+        },
+        [&](const req_type::UnsharpMasking& um) {
+            if (std::holds_alternative<req_type::ToneCurve>(target)) { return true; }
+            if (const auto* umTarget = std::get_if<req_type::UnsharpMasking>(&target))
+            {
+                return umTarget->maskIdx > um.maskIdx;
+            }
+            return false; // target is Sharpening; the chain cannot go backward
+        },
+        [&](const req_type::ToneCurve&) {
+            return false; // tone curve is the terminal step
+        }
+    }, inProgress);
+}
+
+} // namespace
+
 c_Image CreateBlurredMonoImage(const c_Image& source)
 {
     IMPPG_ASSERT(source.GetPixelFormat() == PixelFormat::PIX_MONO32F);
@@ -192,6 +227,8 @@ void c_CpuAndBitmapsProcessing::ScheduleProcessing(ProcessingRequest request)
 {
     if (m_Img.empty()) return;
 
+    const auto originalRequest = request;
+
     // if the previous processing step(s) did not complete, we have to execute it (them) first
     if (std::holds_alternative<req_type::ToneCurve>(request) && !checked_back(m_Output.unsharpMask).valid)
     {
@@ -222,6 +259,18 @@ void c_CpuAndBitmapsProcessing::ScheduleProcessing(ProcessingRequest request)
                 }
             }
         }
+    }
+
+    // If a worker is already running a step that will chain forward through
+    // the originally-requested step, don't interrupt it. The caller already
+    // updated m_ProcSettings via SetProcessingSettings, so when the chain
+    // reaches the relevant step it picks up the new values automatically.
+    // See ChainWillReach() for the rationale.
+    if (IsProcessingInProgress()
+        && m_ProcessingRequest.has_value()
+        && ChainWillReach(*m_ProcessingRequest, originalRequest))
+    {
+        return;
     }
 
     m_ProcessingRequest = request;

--- a/src/backend/src/opengl/opengl_proc.cpp
+++ b/src/backend/src/opengl/opengl_proc.cpp
@@ -220,6 +220,8 @@ c_OpenGLProcessing::c_OpenGLProcessing(unsigned lRCmdBatchSizeMpixIters)
 
 void c_OpenGLProcessing::StartProcessing(ProcessingRequest procRequest)
 {
+    const auto originalRequest = procRequest;
+
     // if the previous processing step(s) did not complete, we have to execute it (them) first
     if (std::holds_alternative<req_type::ToneCurve>(procRequest) && !m_ProcessingOutputValid.unshMask)
     {
@@ -229,6 +231,19 @@ void c_OpenGLProcessing::StartProcessing(ProcessingRequest procRequest)
     if (std::holds_alternative<req_type::UnsharpMasking>(procRequest) && !m_ProcessingOutputValid.sharpening)
     {
         procRequest = req_type::Sharpening{};
+    }
+
+    // If an L-R deconvolution is currently iterating, do not restart it just
+    // because a downstream setting (tone curve or unsharp-mask params) changed.
+    // The L-R loop will chain forward through unsharp masking and tone mapping
+    // when it finishes, picking up the latest m_ProcessingSettings at that
+    // point. Without this guard, rapid curve drags during the iterative L-R
+    // loop would reset and restart it on every drag, preventing completion on
+    // large images.
+    if (m_LRSync.numIterationsLeft > 0
+        && !std::holds_alternative<req_type::Sharpening>(originalRequest))
+    {
+        return;
     }
 
     std::visit(Overload{


### PR DESCRIPTION
## Summary
Rapid tone-curve drags during a slow L-R deconvolution (e.g., when processing a large image after clicking *Select and process whole image*) currently abort and restart the L-R on every drag, so it never completes — only the previously-cached ROI region appears to react. This PR makes the scheduler skip the abort path when the in-flight chain will naturally reach the originally-requested step.

## Repro (before this PR)
1. Open a large image (tested on 3408x3408)
2. Drag a small ROI; the cached intermediates are sized for that ROI
3. Open the tone curve editor and drag a curve point a few times — ROI updates as expected
4. Click *Select and process whole image*
5. **Immediately** start dragging the curve point again
6. Observe: the whole-image L-R never finishes; only the ROI region keeps reacting until you close + reopen the curve editor

## Why it happens
When the curve drag in step 5 fires while L-R is still iterating for the whole image, `ScheduleProcessing(ToneCurve)` (CPU backend) / `StartProcessing(ToneCurve)` (OpenGL backend) gets promoted up to `Sharpening` because the intermediate caches were invalidated by the new selection. The existing code then aborts the in-progress L-R worker and restarts it. With a continuous drag this loop never makes forward progress.

## Fix
Both backends gain a guard: if the currently-executing step will, on completion, naturally chain forward through the originally-requested step, the new `ScheduleProcessing` / `StartProcessing` call becomes a no-op. `m_ProcSettings` is already updated by the caller before scheduling, and each step in the chain reads the latest settings when it starts, so the downstream change still takes effect — just without throwing away the already-running upstream work.

A new `Sharpening` request still restarts L-R (parameters genuinely changed). A same-step `UnsharpMasking{i}` request still restarts that mask. Only chain-will-get-there cases are skipped.

## Test plan
- [x] CPU backend on macOS Tahoe (Apple Silicon, 3408x3408 image): full whole-image L-R completes in ~5s even with continuous curve drags during it; whole image then snaps to the latest curve state immediately.
- [x] OpenGL backend on same setup: same behavior.
- [ ] Confirmed on Linux / Windows (no access here; logic is platform-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)